### PR TITLE
Version 1.1.0

### DIFF
--- a/data/$schema/picker.schema.json
+++ b/data/$schema/picker.schema.json
@@ -14,8 +14,8 @@
           },
           "id": {
             "type": "integer",
-            "description": "Which bit in a merged calendar id that this calendar corresponds to, from least significant",
-            "minimum": 0
+            "description": "Which bit in a merged calendar id that this calendar corresponds to, from least significant. An id of -1 means that this calendar is always hidden and cannot be merged",
+            "minimum": -1
           },
           "order": {
             "type": "integer",
@@ -25,9 +25,17 @@
           "category": {
             "type": "string",
             "description": "The heading of this calendar. Subheadings can be added seperated by /"
+          },
+          "hidden": {
+            "type": "boolean",
+            "description": "If true, this calendar will not be shown in the picker, but can still be used in the URL",
+            "default": false
           }
         },
-        "required": ["filename", "id"]
+        "required": [
+          "filename",
+          "id"
+        ]
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "webcal-adapter",
-  "version": "1.0.0",
+  "name": "cals-cals",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "webcal-adapter",
-      "version": "1.0.0",
+      "name": "cals-cals",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "express": "^4.21.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "buildFrontend": "tsc --project tsconfig.frontend.json && npm run copyPublic && rimraf --glob ./dist/**/*.ts",
     "copyPublic": "node -e \"require('fs').cpSync('./src/frontend', './dist/public', {recursive: true});\"",
     "start": "cd dist && node app.js",
+    "startup": "npm run clean && npm run build && npm run start",
     "test": "jest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcal-adapter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "webcal-adapter",
+  "name": "cals-cals",
   "version": "1.1.0",
-  "description": "",
+  "description": "Calendar website for subscribing to multiple calendars",
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "npm run clean && npm run buildBackend && npm run buildFrontend",
@@ -14,14 +14,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/olillin/WebCal-Adapter.git"
+    "url": "git+https://github.com/olillin/cals-cals.git"
   },
   "author": "Olillin",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/olillin/WebCal-Adapter/issues"
+    "url": "https://github.com/olillin/cals-cals/issues"
   },
-  "homepage": "https://github.com/olillin/WebCal-Adapter#README",
+  "homepage": "https://cal.olillin.com",
   "dependencies": {
     "express": "^4.21.1",
     "iamcal": "^1.0.2",

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -1,0 +1,24 @@
+export interface EnvironmentVariables {
+    PORT?: Number
+}
+
+// Remove 'optional' attributes from a type's properties
+export type Concrete<Type> = {
+    [Property in keyof Type]-?: Type[Property]
+}
+
+export interface PickerCalendar {
+    filename: string
+    id: number
+    order?: number
+    category?: string
+    hidden?: boolean
+}
+
+export interface Picker {
+    calendars: PickerCalendar[]
+}
+
+export interface Redirects {
+    [x: string]: string
+}

--- a/src/frontend/calendar-picker.ts
+++ b/src/frontend/calendar-picker.ts
@@ -10,6 +10,7 @@ interface PickerCalendar {
     id: number
     order?: number
     category?: string
+    hidden?: boolean
 }
 
 interface PickerCalendarTree {
@@ -27,17 +28,23 @@ const picker: Promise<PickerConfig> = (async () => {
 })()
 
 document.addEventListener('DOMContentLoaded', async () => {
-    const calendarContainer = document.getElementById('calendars') as HTMLDivElement
+    const calendarContainer = document.getElementById(
+        'calendars'
+    ) as HTMLDivElement
 
     const calendarTree: PickerCalendarTree = {}
     function addCalendar(calendar: PickerCalendar) {
         if (calendar.category) {
-            let tokens: string[] = calendar.category.split('/').filter(token => token.trim().length)
+            let tokens: string[] = calendar.category
+                .split('/')
+                .filter(token => token.trim().length)
             let latest: string
             let node: PickerCalendarTree = calendarTree
             while (tokens.length > 0) {
                 ;[latest, ...tokens] = tokens
-                let subcategory = node.subcategories?.find(s => s.name === latest)
+                let subcategory = node.subcategories?.find(
+                    s => s.name === latest
+                )
                 if (subcategory) {
                     node = subcategory
                 } else {
@@ -65,9 +72,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    ;(await picker).calendars.forEach(calendar => {
-        addCalendar(calendar)
-    })
+    ;(await picker).calendars
+        .filter(calendar => calendar.hidden !== true)
+        .forEach(calendar => {
+            addCalendar(calendar)
+        })
 
     renderTree(calendarTree, calendarContainer)
     update()
@@ -84,7 +93,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 })
 
-function renderTree(tree: PickerCalendarTree | PickerCalendarSubTree, container: HTMLElement, depth: number = 2) {
+function renderTree(
+    tree: PickerCalendarTree | PickerCalendarSubTree,
+    container: HTMLElement,
+    depth: number = 2
+) {
     if (depth > 6) {
         throw Error(`Unable to create header for depth ${depth}`)
     }
@@ -120,7 +133,9 @@ function renderTree(tree: PickerCalendarTree | PickerCalendarSubTree, container:
 
     // Render subcategories
     const subCategories = tree.subcategories ?? []
-    const sortedCategories = subCategories.sort((a, b) => a.name.localeCompare(b.name))
+    const sortedCategories = subCategories.sort((a, b) =>
+        a.name.localeCompare(b.name)
+    )
     sortedCategories.forEach(category => {
         renderTree(category, subContainer, depth + 1)
     })
@@ -149,7 +164,10 @@ function createSelectAllButton(group: HTMLElement) {
     return selectAll
 }
 
-async function makeCalendarButton(button: HTMLButtonElement, calendar: PickerCalendar) {
+async function makeCalendarButton(
+    button: HTMLButtonElement,
+    calendar: PickerCalendar
+) {
     // Data
     button.setAttribute('data-calendar-id', calendar.id.toString())
     button.setAttribute('data-calendar-filename', calendar.filename)
@@ -184,7 +202,9 @@ function getIndex(indexUrl: string): Promise<string[]> {
             }
 
             const text = await response.text()
-            const lines = text.split('\n').filter(line => line.trim().length > 0)
+            const lines = text
+                .split('\n')
+                .filter(line => line.trim().length > 0)
 
             resolve(lines)
         })
@@ -211,23 +231,39 @@ function getCalendarName(filename: string): Promise<string> {
 
 function update() {
     // Get elements
-    const calendarContainer = document.getElementById('calendars') as HTMLDivElement
-    const calendarUrl = document.getElementById('calendar-url') as HTMLInputElement
-    const showOrigin = document.getElementById('show-origin') as HTMLInputElement
+    const calendarContainer = document.getElementById(
+        'calendars'
+    ) as HTMLDivElement
+    const calendarUrl = document.getElementById(
+        'calendar-url'
+    ) as HTMLInputElement
+    const showOrigin = document.getElementById(
+        'show-origin'
+    ) as HTMLInputElement
 
-    const showOriginSection = document.getElementById('show-origin-section') as HTMLSpanElement
+    const showOriginSection = document.getElementById(
+        'show-origin-section'
+    ) as HTMLSpanElement
     showOriginSection.hidden = true
-    const calendarUrlSection = document.getElementById('calendar-url-section') as HTMLSpanElement
+    const calendarUrlSection = document.getElementById(
+        'calendar-url-section'
+    ) as HTMLSpanElement
     calendarUrlSection.hidden = false
 
     // Get domain name
     const urlBase = window.location.origin
 
     // Find selected elements
-    const elements = Array.from(calendarContainer.getElementsByClassName('calendar-item'))
-    const selectedElements = Array.from(calendarContainer.getElementsByClassName(selectedClassName))
+    const elements = Array.from(
+        calendarContainer.getElementsByClassName('calendar-item')
+    )
+    const selectedElements = Array.from(
+        calendarContainer.getElementsByClassName(selectedClassName)
+    )
     if (selectedElements.length == 1) {
-        const filename = selectedElements[0].getAttribute('data-calendar-filename')
+        const filename = selectedElements[0].getAttribute(
+            'data-calendar-filename'
+        )
 
         calendarUrl.value = `${urlBase}/c/${filename}`
     } else if (selectedElements.length > 1) {
@@ -265,7 +301,9 @@ function update() {
 }
 
 function copyUrl() {
-    const calendarUrl = document.getElementById('calendar-url') as HTMLInputElement
+    const calendarUrl = document.getElementById(
+        'calendar-url'
+    ) as HTMLInputElement
     const copyNotice = document.getElementById('copy-notice') as HTMLSpanElement
 
     calendarUrl.select()
@@ -280,7 +318,9 @@ function copyUrl() {
 }
 
 function select(predicate: (el: Element) => boolean) {
-    const calendarContainer = document.getElementById('calendars') as HTMLDivElement
+    const calendarContainer = document.getElementById(
+        'calendars'
+    ) as HTMLDivElement
 
     const elements = calendarContainer.getElementsByClassName('calendar-item')
     for (const element of elements) {
@@ -292,7 +332,9 @@ function select(predicate: (el: Element) => boolean) {
 }
 
 function unselect(predicate: (el: Element) => boolean) {
-    const calendarContainer = document.getElementById('calendars') as HTMLDivElement
+    const calendarContainer = document.getElementById(
+        'calendars'
+    ) as HTMLDivElement
 
     const elements = calendarContainer.getElementsByClassName('calendar-item')
     for (const element of elements) {


### PR DESCRIPTION
## New features

+ A calendar id of -1 hides the calendar and prevents merging. Essentially making a "private" calendar which can only be accessed through a direct link. The calendar does **not** appear in `/picker.json`
+ The new `hidden` property in `picker.json` will hide the calendar from the website. It is however still present in `/picker.json` fetched from the backend and the calendar can still be fetched from the same URL as if it was not hidden
+ New `npm run startup` command will build and run the project, removing any previous build

## Related issues

- Closes #17